### PR TITLE
Sinytra Connector + Farmer's Delight Compat

### DIFF
--- a/src/main/java/com/teamabode/verdance/core/integration/farmersdelight/FDIntegration.java
+++ b/src/main/java/com/teamabode/verdance/core/integration/farmersdelight/FDIntegration.java
@@ -7,11 +7,10 @@ import com.teamabode.verdance.core.integration.farmersdelight.registry.FDCompatS
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.item.ItemGroup;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
-import vectorwing.farmersdelight.common.registry.ModBlocks;
-import vectorwing.farmersdelight.common.registry.ModItems;
 
 public class FDIntegration {
     private static final RegistryKey<ItemGroup> TAB_FARMERS_DELIGHT = RegistryKey.of(
@@ -25,10 +24,14 @@ public class FDIntegration {
         FDCompatSoundEvents.register();
 
         ItemGroupEvents.modifyEntriesEvent(TAB_FARMERS_DELIGHT).register(entries -> {
-            entries.addAfter(ModItems.ONION_CRATE.get(), FDCompatBlocks.MULBERRY_CRATE);
-            entries.addAfter(ModBlocks.CHERRY_CABINET.get(), FDCompatBlocks.MULBERRY_CABINET);
+            entries.addAfter(Registries.ITEM.get(new Identifier("farmersdelight", "onion_crate")), FDCompatBlocks.MULBERRY_CRATE);
+            entries.addAfter(Registries.ITEM.get(new Identifier("farmersdelight", "cherry_cabinet")), FDCompatBlocks.MULBERRY_CABINET);
         });
-        CompatUtils.registerBuiltinPack("farmersdelight_datapack", container);
+        if (CompatUtils.isModLoaded("connectormod")) {
+            CompatUtils.registerBuiltinPack("forge_farmersdelight_datapack", container);
+        } else {
+            CompatUtils.registerBuiltinPack("farmersdelight_datapack", container);
+        }
         CompatUtils.registerBuiltinPack("farmersdelight_resourcepack", container);
     }
 }

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/farmersdelight/tags/items/cabinets/wooden.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/farmersdelight/tags/items/cabinets/wooden.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "verdance:mulberry_cabinet"
+    ]
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "verdance:mulberry_cabinet",
+        "verdance:mulberry_crate"
+    ]
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/advancements/recipes/decorations/mulberry_cabinet.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/advancements/recipes/decorations/mulberry_cabinet.json
@@ -1,0 +1,25 @@
+{
+    "parent": "minecraft:recipes/root",
+    "criteria": {
+        "has_mulberry_trapdoor": {
+            "conditions": {
+                "items": [
+                    {
+                        "items": ["verdance:mulberry_trapdoor"]
+                    }
+                ]
+            },
+            "trigger": "minecraft:inventory_changed"
+        },
+        "has_the_recipe": {
+            "conditions": {
+                "recipe": "verdance:mulberry_cabinet"
+            },
+            "trigger": "minecraft:recipe_unlocked"
+        }
+    },
+    "requirements": [["has_the_recipe", "has_mulberry_trapdoor"]],
+    "rewards": {
+        "recipes": ["verdance:mulberry_cabinet"]
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/advancements/recipes/decorations/mulberry_crate.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/advancements/recipes/decorations/mulberry_crate.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "criteria": {
+        "has_mulberry": {
+            "conditions": {
+                "items": [
+                    {
+                        "items": ["verdance:mulberry"]
+                    }
+                ]
+            },
+            "trigger": "minecraft:inventory_changed"
+        },
+        "has_the_recipe": {
+            "conditions": {
+                "recipe": "verdance:mulberry_crate"
+            },
+            "trigger": "minecraft:recipe_unlocked"
+        }
+    },
+    "requirements": [
+        [
+            "has_the_recipe",
+            "has_mulberry"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "verdance:mulberry_crate"
+        ]
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/advancements/recipes/foods/mulberry.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/advancements/recipes/foods/mulberry.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "criteria": {
+        "has_mulberry_crate": {
+            "conditions": {
+                "items": [
+                    {
+                        "items": ["verdance:mulberry_crate"]
+                    }
+                ]
+            },
+            "trigger": "minecraft:inventory_changed"
+        },
+        "has_the_recipe": {
+            "conditions": {
+                "recipe": "verdance:mulberry"
+            },
+            "trigger": "minecraft:recipe_unlocked"
+        }
+    },
+    "requirements": [
+        [
+            "has_the_recipe",
+            "has_mulberry_crate"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "verdance:mulberry"
+        ]
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/cantaloupe.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/cantaloupe.json
@@ -1,0 +1,17 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:cantaloupe"
+        }
+    ],
+    "result": [
+        {
+            "count": 4,
+            "item": "verdance:cantaloupe_slice"
+        }
+    ],
+    "tool": {
+        "tag": "forge:tools/knives"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_door.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_door.json
@@ -1,0 +1,17 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:mulberry_door"
+        }
+    ],
+    "result": [
+        {
+            "item": "verdance:mulberry_planks"
+        }
+    ],
+    "tool": {
+        "fabric:type": "farmersdelight:tool_action",
+        "action": "axe_dig"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_hanging_sign.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_hanging_sign.json
@@ -1,0 +1,17 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:mulberry_hanging_sign"
+        }
+    ],
+    "result": [
+        {
+            "item": "verdance:mulberry_planks"
+        }
+    ],
+    "tool": {
+        "fabric:type": "farmersdelight:tool_action",
+        "action": "axe_dig"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_log.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_log.json
@@ -1,0 +1,21 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:mulberry_log"
+        }
+    ],
+    "result": [
+        {
+            "item": "verdance:stripped_mulberry_log"
+        },
+        {
+            "item": "farmersdelight:tree_bark"
+        }
+    ],
+    "sound": "minecraft:item.axe.strip",
+    "tool": {
+        "fabric:type": "farmersdelight:tool_action",
+        "action": "axe_strip"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_sign.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_sign.json
@@ -1,0 +1,17 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:mulberry_sign"
+        }
+    ],
+    "result": [
+        {
+            "item": "verdance:mulberry_planks"
+        }
+    ],
+    "tool": {
+        "fabric:type": "farmersdelight:tool_action",
+        "action": "axe_dig"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_trapdoor.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_trapdoor.json
@@ -1,0 +1,17 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:mulberry_trapdoor"
+        }
+    ],
+    "result": [
+        {
+            "item": "verdance:mulberry_planks"
+        }
+    ],
+    "tool": {
+        "fabric:type": "farmersdelight:tool_action",
+        "action": "axe_dig"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_wood.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/mulberry_wood.json
@@ -1,0 +1,21 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:mulberry_wood"
+        }
+    ],
+    "result": [
+        {
+            "item": "verdance:stripped_mulberry_wood"
+        },
+        {
+            "item": "farmersdelight:tree_bark"
+        }
+    ],
+    "sound": "minecraft:item.axe.strip",
+    "tool": {
+        "fabric:type": "farmersdelight:tool_action",
+        "action": "axe_strip"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/violet.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/cutting/violet.json
@@ -1,0 +1,17 @@
+{
+    "type": "farmersdelight:cutting",
+    "ingredients": [
+        {
+            "item": "verdance:violet"
+        }
+    ],
+    "result": [
+        {
+            "item": "minecraft:purple_dye",
+            "count": 2
+        }
+    ],
+    "tool": {
+        "tag": "forge:tools/knives"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/mulberry.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/mulberry.json
@@ -1,0 +1,13 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "category": "misc",
+    "ingredients": [
+        {
+            "item": "verdance:mulberry_crate"
+        }
+    ],
+    "result": {
+        "count": 9,
+        "item": "verdance:mulberry"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/mulberry_cabinet.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/mulberry_cabinet.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+        "D": {
+            "item": "verdance:mulberry_trapdoor"
+        },
+        "_": {
+            "item": "verdance:mulberry_slab"
+        }
+    },
+    "pattern": ["___", "D D", "___"],
+    "result": {
+        "count": 1,
+        "item": "verdance:mulberry_cabinet"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/mulberry_crate.json
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/data/verdance/recipes/mulberry_crate.json
@@ -1,0 +1,18 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "category": "misc",
+    "key": {
+        "#": {
+            "item": "verdance:mulberry"
+        }
+    },
+    "pattern": [
+        "###",
+        "###",
+        "###"
+    ],
+    "result": {
+        "count": 1,
+        "item": "verdance:mulberry_crate"
+    }
+}

--- a/src/main/resources/resourcepacks/forge_farmersdelight_datapack/pack.mcmeta
+++ b/src/main/resources/resourcepacks/forge_farmersdelight_datapack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "description": "Compatibility for Forge Farmer's Delight",
+        "pack_format": 15
+    }
+}


### PR DESCRIPTION
Tested on latest fabric version and tested on latest forge version.

Fixes crashes and recipe errors when Sinytra Connector, Farmer's Delight and Verdance are all used in one modpack.
